### PR TITLE
Fix a bug about the release VERSION detection

### DIFF
--- a/test_cgal.py
+++ b/test_cgal.py
@@ -448,7 +448,7 @@ def main():
                     print 'Container died cleanly, handling results'
                     try:
                         handle_results(ev[u'id'], args.upload_results, args.testresults,
-                                       args.testsuite, args.tester)
+                                       path_to_extracted_release, args.tester)
                     except TestsuiteException as e:
                         print e
                 # The freed up cpu_set.


### PR DESCRIPTION
Without this patch, when `test_cgal.py` is used without argument, and the latest version of CGAL is downloaded and tested, then the detection of `VERSION` is wrong.
